### PR TITLE
feat(auth): JWT 인증 필터 및 Role(권한) 기반 인가 구현

### DIFF
--- a/FlowPlanServer/src/main/java/com/hanmo/flowplan/global/config/SecurityConfig.java
+++ b/FlowPlanServer/src/main/java/com/hanmo/flowplan/global/config/SecurityConfig.java
@@ -1,17 +1,23 @@
 package com.hanmo.flowplan.global.config;
 
+import com.hanmo.flowplan.global.jwt.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+  private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -23,6 +29,7 @@ public class SecurityConfig {
               .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
               .authorizeHttpRequests(auth -> auth
                       // OAuth2 관련 경로는 공개
+                      .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                       .requestMatchers(
                           "/api/auth/google/login",
                           "/swagger-ui.html",
@@ -32,7 +39,8 @@ public class SecurityConfig {
                       ).permitAll()
                       // 나머지 요청은 인증 필요
                       .anyRequest().authenticated()
-              );
+
+              ).addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);;
 
       // OAuth2 설정은 나중 단계에서 아래 블록을 추가
       // .oauth2Login(oauth -> oauth

--- a/FlowPlanServer/src/main/java/com/hanmo/flowplan/global/jwt/JwtAuthenticationFilter.java
+++ b/FlowPlanServer/src/main/java/com/hanmo/flowplan/global/jwt/JwtAuthenticationFilter.java
@@ -26,7 +26,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     // 1. Request Header에서 Access Token 추출
     String at = jwtProvider.resolveAccessToken(request);
-
     // 2. 토큰이 유효한지 검증
     if (at != null) {
       try {

--- a/FlowPlanServer/src/main/java/com/hanmo/flowplan/global/jwt/JwtAuthenticationFilter.java
+++ b/FlowPlanServer/src/main/java/com/hanmo/flowplan/global/jwt/JwtAuthenticationFilter.java
@@ -1,4 +1,44 @@
 package com.hanmo.flowplan.global.jwt;
 
-public class JwtAuthenticationFilter {
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+  private final JwtProvider jwtProvider;
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+    // 1. Request Header에서 Access Token 추출
+    String at = jwtProvider.resolveAccessToken(request);
+
+    // 2. 토큰이 유효한지 검증
+    if (at != null) {
+      try {
+        jwtProvider.validate(at);
+        Authentication auth = jwtProvider.getAuthentication(at);
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+      } catch (IllegalArgumentException | IllegalStateException e) {
+        SecurityContextHolder.clearContext();
+      }
+    }
+    // 6. 다음 필터로 진행
+    filterChain.doFilter(request, response);
+  }
 }

--- a/FlowPlanServer/src/main/java/com/hanmo/flowplan/global/jwt/JwtAuthenticationFilter.java
+++ b/FlowPlanServer/src/main/java/com/hanmo/flowplan/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,4 @@
+package com.hanmo.flowplan.global.jwt;
+
+public class JwtAuthenticationFilter {
+}

--- a/FlowPlanServer/src/main/java/com/hanmo/flowplan/global/jwt/JwtConstant.java
+++ b/FlowPlanServer/src/main/java/com/hanmo/flowplan/global/jwt/JwtConstant.java
@@ -3,6 +3,6 @@ package com.hanmo.flowplan.global.jwt;
 public final class JwtConstant {
     private JwtConstant() {}
     public static final String GRANT_TYPE = "Bearer";
-    public static final long ACCESS_TOKEN_EXPIRE_TIME = 60 * 60 * 1000L;        // 1h
+    public static final long ACCESS_TOKEN_EXPIRE_TIME = 60 * 60 * 1000L;        // 1h -> reissue 할때 5분으로 변경
     public static final long REFRESH_TOKEN_EXPIRE_TIME = 7 * 24 * 60 * 60 * 1000L; // 7d
 }

--- a/FlowPlanServer/src/main/java/com/hanmo/flowplan/global/jwt/JwtProvider.java
+++ b/FlowPlanServer/src/main/java/com/hanmo/flowplan/global/jwt/JwtProvider.java
@@ -106,7 +106,7 @@ public class JwtProvider {
 
   public Authentication getAuthentication(String token) {
     String googleId = getGoogleIdFromToken(token);
-    User user = userRepository.findByEmail(googleId)
+    User user = userRepository.findByGoogleId(googleId)
         .orElseThrow(() -> new UsernameNotFoundException("User not found: " + googleId));
     Collection<GrantedAuthority> auths = List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()));
 

--- a/FlowPlanServer/src/main/java/com/hanmo/flowplan/global/jwt/JwtProvider.java
+++ b/FlowPlanServer/src/main/java/com/hanmo/flowplan/global/jwt/JwtProvider.java
@@ -1,103 +1,126 @@
 package com.hanmo.flowplan.global.jwt;
 
+import com.hanmo.flowplan.user.domain.User;
+import com.hanmo.flowplan.user.domain.UserRepository;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
 
 import java.security.Key;
+import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 
 import static com.hanmo.flowplan.global.jwt.JwtConstant.*;
 
 @Component
 public class JwtProvider {
 
-    private final Key key;
+  private static final String TOKEN_SUBJECT = "FlowPlan";
 
-    public JwtProvider(@Value("${jwt.secretKey}") String base64SecretKey) {
-        byte[] keyBytes = Decoders.BASE64.decode(base64SecretKey.trim());
-        if (keyBytes.length < 32) { // HS256 최소 256비트
-            throw new IllegalArgumentException("jwt.secretKey must be 256-bit (Base64).");
-        }
-        this.key = Keys.hmacShaKeyFor(keyBytes);
-    }
+  private final UserRepository userRepository;
+  private final Key key;
 
-    public JwtToken issueToken(String username) {
-        String at = createAccessToken(username, "ROLE_USER");
-        String rt = createRefreshToken(username);
-        return new JwtToken(GRANT_TYPE, at, rt);
-    }
+  public JwtProvider(@Value("${jwt.secretKey}") String base64SecretKey, UserRepository userRepository) {
+      this.userRepository = userRepository;
+      byte[] keyBytes = Decoders.BASE64.decode(base64SecretKey.trim());
+      if (keyBytes.length < 32) { // HS256 최소 256비트
+          throw new IllegalArgumentException("jwt.secretKey must be 256-bit (Base64).");
+      }
+      this.key = Keys.hmacShaKeyFor(keyBytes);
+  }
 
-    public JwtToken reissue(String refreshToken) {
-        assertRefreshToken(refreshToken);
-        String username = getUsernameFromToken(refreshToken);
-        return issueToken(username);
-    }
+  public JwtToken issueToken(String googleId) {
+      String at = createAccessToken(googleId);
+      String rt = createRefreshToken(googleId);
+      return new JwtToken(GRANT_TYPE, at, rt);
+  }
 
-    public String createAccessToken(String username, String authorities) {
-        long now = System.currentTimeMillis();
-        Date exp = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
-        return Jwts.builder()
-                .setSubject(username)
-                .claim("authorities", authorities)
-                .claim("type", "access")
-                .setExpiration(exp)
-                .signWith(key, SignatureAlgorithm.HS256)
-                .compact();
-    }
+  public JwtToken reissue(String refreshToken) {
+      assertRefreshToken(refreshToken);
+      String googleId = getGoogleIdFromToken(refreshToken);
+      return issueToken(googleId);
+  }
 
-    public String createRefreshToken(String username) {
-        long now = System.currentTimeMillis();
-        Date exp = new Date(now + REFRESH_TOKEN_EXPIRE_TIME);
-        return Jwts.builder()
-                .setSubject(username)
-                .claim("type", "refresh")
-                .setExpiration(exp)
-                .signWith(key, SignatureAlgorithm.HS256)
-                .compact();
-    }
+  public String createAccessToken(String googleId) {
+      long now = System.currentTimeMillis();
+      Date exp = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
+      return Jwts.builder()
+              .setSubject(TOKEN_SUBJECT)
+              .claim("googleId", googleId)
+              .claim("type", "access")
+              .setExpiration(exp)
+              .signWith(key, SignatureAlgorithm.HS256)
+              .compact();
+  }
 
-    public void setHeaderAccessToken(HttpServletResponse response, String accessToken) {
-        response.setHeader("Authorization", GRANT_TYPE + " " + accessToken);
-    }
+  public String createRefreshToken(String googleId) {
+      long now = System.currentTimeMillis();
+      Date exp = new Date(now + REFRESH_TOKEN_EXPIRE_TIME);
+      return Jwts.builder()
+              .setSubject(TOKEN_SUBJECT)
+              .claim("googleId", googleId)
+              .claim("type", "refresh")
+              .setExpiration(exp)
+              .signWith(key, SignatureAlgorithm.HS256)
+              .compact();
+  }
 
-    public void setHeaderRefreshToken(HttpServletResponse response, String refreshToken) {
-        response.setHeader("Refresh-Token", refreshToken);
-    }
+  public void setHeaderAccessToken(HttpServletResponse response, String accessToken) {
+      response.setHeader("Authorization", GRANT_TYPE + " " + accessToken);
+  }
 
-    public void assertRefreshToken(String token) {
-        validate(token);
-        String type = (String) parseClaims(token).get("type");
-        if (!"refresh".equals(type)) throw new IllegalArgumentException("Not a refresh token.");
-    }
+  public void setHeaderRefreshToken(HttpServletResponse response, String refreshToken) {
+      response.setHeader("Refresh-Token", refreshToken);
+  }
 
-    public boolean validate(String token) {
-        parseClaims(token);
-        return true;
-    }
+  public void assertRefreshToken(String token) {
+      validate(token);
+      String type = (String) parseClaims(token).get("type");
+      if (!"refresh".equals(type)) throw new IllegalArgumentException("Not a refresh token.");
+  }
 
-    public String getUsernameFromToken(String token) {
-        return parseClaims(token).getSubject();
-    }
+  public boolean validate(String token) {
+      parseClaims(token);
+      return true;
+  }
 
-    public String resolveAccessToken(HttpServletRequest request) {
-        String bearer = request.getHeader("Authorization");
-        if (bearer == null || !bearer.startsWith(GRANT_TYPE + " ")) return null;
-        return bearer.substring((GRANT_TYPE + " ").length());
-    }
+  public String getGoogleIdFromToken(String token) {
+      return parseClaims(token).get("googleId", String.class);
+  }
 
-    private Claims parseClaims(String token) {
-        try {
-            return Jwts.parserBuilder().setSigningKey(key).build()
-                    .parseClaimsJws(token).getBody();
-        } catch (ExpiredJwtException e) {
-            throw new IllegalStateException("만료된 토큰");
-        } catch (JwtException e) {
-            throw new IllegalArgumentException("유효하지 않은 토큰");
-        }
-    }
+  public String resolveAccessToken(HttpServletRequest request) {
+      String bearer = request.getHeader("Authorization");
+      if (bearer == null || !bearer.startsWith(GRANT_TYPE + " ")) return null;
+      return bearer.substring((GRANT_TYPE + " ").length());
+  }
+
+  public Authentication getAuthentication(String token) {
+    String googleId = getGoogleIdFromToken(token);
+    User user = userRepository.findByEmail(googleId)
+        .orElseThrow(() -> new UsernameNotFoundException("User not found: " + googleId));
+    Collection<GrantedAuthority> auths = List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()));
+
+    return new UsernamePasswordAuthenticationToken(user, null, auths);
+  }
+
+  private Claims parseClaims(String token) {
+      try {
+          return Jwts.parserBuilder().setSigningKey(key).build()
+                  .parseClaimsJws(token).getBody();
+      } catch (ExpiredJwtException e) {
+          throw new IllegalStateException("만료된 토큰");
+      } catch (JwtException e) {
+          throw new IllegalArgumentException("유효하지 않은 토큰");
+      }
+  }
 }

--- a/FlowPlanServer/src/main/java/com/hanmo/flowplan/user/application/GoogleOAuthService.java
+++ b/FlowPlanServer/src/main/java/com/hanmo/flowplan/user/application/GoogleOAuthService.java
@@ -66,8 +66,8 @@ public class GoogleOAuthService {
     // 로그아웃 (AT 무효화는 보통 블랙리스트 or 만료 대기. 여기선 RT 삭제만)
     public void logout(String accessToken) {
         if (accessToken == null) return;
-        String email = jwtProvider.getGoogleIdFromToken(accessToken);
-        refreshTokenStore.delete(email);
+        String googleId = jwtProvider.getGoogleIdFromToken(accessToken);
+        refreshTokenStore.delete(googleId);
         // TODO: 필요 시 AccessToken 블랙리스트 처리
     }
 }

--- a/FlowPlanServer/src/main/java/com/hanmo/flowplan/user/application/GoogleOAuthService.java
+++ b/FlowPlanServer/src/main/java/com/hanmo/flowplan/user/application/GoogleOAuthService.java
@@ -36,7 +36,7 @@ public class GoogleOAuthService {
                         .build()
         ));
 
-        JwtToken jwt = jwtProvider.issueToken(user.getEmail());
+        JwtToken jwt = jwtProvider.issueToken(user.getGoogleId());
         refreshTokenStore.save(user.getEmail(), jwt.refreshToken());
 
         return new AuthResult(user.getId(), user.getEmail(), user.getName(), isNew, jwt);
@@ -51,7 +51,7 @@ public class GoogleOAuthService {
     // 재발급
     public JwtToken reissueTokens(String refreshToken) {
         jwtProvider.assertRefreshToken(refreshToken);
-        String email = jwtProvider.getUsernameFromToken(refreshToken);
+        String email = jwtProvider.getGoogleIdFromToken(refreshToken);
 
         String stored = refreshTokenStore.get(email);
         if (stored == null || !stored.equals(refreshToken)) {
@@ -66,7 +66,7 @@ public class GoogleOAuthService {
     // 로그아웃 (AT 무효화는 보통 블랙리스트 or 만료 대기. 여기선 RT 삭제만)
     public void logout(String accessToken) {
         if (accessToken == null) return;
-        String email = jwtProvider.getUsernameFromToken(accessToken);
+        String email = jwtProvider.getGoogleIdFromToken(accessToken);
         refreshTokenStore.delete(email);
         // TODO: 필요 시 AccessToken 블랙리스트 처리
     }

--- a/FlowPlanServer/src/main/java/com/hanmo/flowplan/user/domain/User.java
+++ b/FlowPlanServer/src/main/java/com/hanmo/flowplan/user/domain/User.java
@@ -26,6 +26,7 @@ public class User extends BaseTimeEntity {
     private String googleId;
 
     @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     private UserRole role;
 
     @Builder

--- a/FlowPlanServer/src/main/java/com/hanmo/flowplan/user/domain/User.java
+++ b/FlowPlanServer/src/main/java/com/hanmo/flowplan/user/domain/User.java
@@ -25,10 +25,14 @@ public class User extends BaseTimeEntity {
     @Column(name = "google_id", nullable = false)
     private String googleId;
 
+    @Column(nullable = false)
+    private UserRole role;
+
     @Builder
     public User(String email, String name, String googleId) {
         this.email = email;
         this.name = name;
         this.googleId = googleId;
+        this.role = UserRole.USER; // 기본 역할 설정
     }
 }

--- a/FlowPlanServer/src/main/java/com/hanmo/flowplan/user/domain/UserRole.java
+++ b/FlowPlanServer/src/main/java/com/hanmo/flowplan/user/domain/UserRole.java
@@ -1,6 +1,6 @@
 package com.hanmo.flowplan.user.domain;
 
 public enum UserRole {
-    USER,
+    USER
 //    ADMIN // 추후 관리자 기능이 필요할 경우를 대비해 남겨둠
 }

--- a/FlowPlanServer/src/main/java/com/hanmo/flowplan/user/domain/UserRole.java
+++ b/FlowPlanServer/src/main/java/com/hanmo/flowplan/user/domain/UserRole.java
@@ -1,0 +1,4 @@
+package com.hanmo.flowplan.user.domain;
+
+public enum UserRole {
+}

--- a/FlowPlanServer/src/main/java/com/hanmo/flowplan/user/domain/UserRole.java
+++ b/FlowPlanServer/src/main/java/com/hanmo/flowplan/user/domain/UserRole.java
@@ -1,4 +1,6 @@
 package com.hanmo.flowplan.user.domain;
 
 public enum UserRole {
+    USER,
+//    ADMIN // 추후 관리자 기능이 필요할 경우를 대비해 남겨둠
 }


### PR DESCRIPTION
## feat(auth): JWT 인증 필터 및 Role(권한) 기반 인가 구현

### Description

로그인(`permitAll`) 외의 모든 API 접근 시 발생하던 **403 Forbidden 오류를 해결**하고, JWT를 이용한 전체 인증/인가 로직을 완성합니다.

`JwtAuthenticationFilter`를 `SecurityConfig`에 정식으로 등록하여, `Authorization` 헤더로 전달된 Access Token을 검증하고 사용자의 실제 권한(Role)을 SecurityContext에 등록하도록 구현했습니다.

### Key Changes

* **`SecurityConfig.java`**
    * `addFilterBefore`를 사용해 `JwtAuthenticationFilter`를 `UsernamePasswordAuthenticationFilter` 앞에 배치하여, 모든 인증 요청을 JWT 필터가 먼저 처리하도록 수정했습니다.
* **`JwtAuthenticationFilter.java`**
    * `doFilterInternal` 메서드에서 Access Token을 추출하고, `JwtProvider`를 호출하여 인증(`Authentication`) 객체를 받아옵니다.
    * `SecurityContextHolder`에 인증 객체를 저장하여 "인증된 사용자"로 처리되도록 수정했습니다. (403 오류 해결)
* **`JwtProvider.java`**
    * `getAuthentication` 메서드를 추가했습니다.
    * 이 메서드는 토큰에서 `googleId`를 추출 ➡️ `userRepository.findByGoogleId`로 DB 조회 ➡️ `user.getRole()`을 기반으로 `Authentication` 객체를 생성하여 반환합니다.
* **`GoogleOAuthService.java` / `User.java` / `UserRole.java`**
    * 신규 회원가입 시, `User` 엔티티의 `role` 필드에 기본값으로 `UserRole.USER`가 저장되도록 수정했습니다.

### How to Test

1.  로컬 또는 서버에서 `POST /api/auth/google/login`을 통해 구글 로그인 후 **Access Token**을 발급받습니다.
2.  Swagger 페이지 우측 상단의 **`Authorize`** 버튼을 눌러 발급받은 Access Token을 `Bearer ...` 형식으로 등록합니다.
3.  인증이 필요한 API (예: `POST /api/auth/logout`)를 실행합니다.
4.  기존 `403 Forbidden` 오류 대신, `204 No Content` (로그아웃 성공) 응답이 오는지 확인합니다.