### PR TITLE
feat(task): 작업(Task) CRUD API 구현 및 인증/검증 로직 고도화

### DIFF
--- a/FlowPlanServer/src/main/java/com/hanmo/flowplan/global/config/SecurityConfig.java
+++ b/FlowPlanServer/src/main/java/com/hanmo/flowplan/global/config/SecurityConfig.java
@@ -31,7 +31,6 @@ public class SecurityConfig {
               .authorizeHttpRequests(auth -> auth
                       .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                       // OAuth2 관련 경로는 공개
-                      .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                       .requestMatchers(
                           "/api/swagger-ui/index.html",
                           "/api/auth/google/login",

--- a/FlowPlanServer/src/main/java/com/hanmo/flowplan/global/jwt/CustomUserDetails.java
+++ b/FlowPlanServer/src/main/java/com/hanmo/flowplan/global/jwt/CustomUserDetails.java
@@ -4,6 +4,7 @@ import com.hanmo.flowplan.user.domain.User;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
@@ -17,7 +18,7 @@ public class CustomUserDetails  implements UserDetails {
 
   @Override
   public Collection<? extends GrantedAuthority> getAuthorities() {
-    return List.of();
+    return List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole()));
   }
 
   // ⭐️ 우리가 원하는 'googleId'를 반환하는 커스텀 메서드

--- a/FlowPlanServer/src/main/java/com/hanmo/flowplan/project/application/ProjectService.java
+++ b/FlowPlanServer/src/main/java/com/hanmo/flowplan/project/application/ProjectService.java
@@ -28,7 +28,6 @@ public class ProjectService {
   private final ProjectRepository projectRepository;
   private final UserRepository userRepository;
   private final ProjectMemberRepository projectMemberRepository;
-  private final JwtProvider jwtProvider;
   private final AiDtoMapper aiDtoMapper; // (DTO 변환기)
   private final AiService aiService;     // (AI 호출 담당)
   private final TaskService taskService;   // (WBS 저장 담당)
@@ -81,7 +80,8 @@ public class ProjectService {
 
     // 2. (WBS 저장) - TaskService를 통해 WBS 항목 저장
     taskService.saveTasksFromAiResponse(user, project, wbsResponseDto);
-
   }
+
+
 
 }

--- a/FlowPlanServer/src/main/java/com/hanmo/flowplan/projectMember/application/validator/ProjectMemberValidator.java
+++ b/FlowPlanServer/src/main/java/com/hanmo/flowplan/projectMember/application/validator/ProjectMemberValidator.java
@@ -1,0 +1,36 @@
+package com.hanmo.flowplan.projectMember.application.validator;
+
+import com.hanmo.flowplan.project.domain.Project;
+import com.hanmo.flowplan.project.domain.ProjectRepository;
+import com.hanmo.flowplan.projectMember.domain.ProjectMemberRepository;
+import com.hanmo.flowplan.user.domain.User;
+import com.hanmo.flowplan.user.domain.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component // ⭐️ @Service 대신 @Component (역할이 "검증"이므로)
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProjectMemberValidator {
+
+  private final UserRepository userRepository;
+  private final ProjectRepository projectRepository;
+  private final ProjectMemberRepository projectMemberRepository;
+
+  public Project validateMembership(String googleId, Long projectId) {
+    User user = userRepository.findByGoogleId(googleId)
+        .orElseThrow(() -> new UsernameNotFoundException("User not found with googleId: " + googleId));
+
+    Project project = projectRepository.findById(projectId)
+        .orElseThrow(() -> new IllegalArgumentException("Project not found with id: " + projectId));
+
+    if (!projectMemberRepository.existsByUserAndProject(user, project)) {
+      throw new AccessDeniedException("User is not a member of this project");
+    }
+
+    return project;
+  }
+}

--- a/FlowPlanServer/src/main/java/com/hanmo/flowplan/projectMember/domain/ProjectMemberRepository.java
+++ b/FlowPlanServer/src/main/java/com/hanmo/flowplan/projectMember/domain/ProjectMemberRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 
 public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Long> {
   Optional<ProjectMember> findByUserAndProject(User user, Project project);
+  boolean existsByUserAndProject(User user, Project project);
 }

--- a/FlowPlanServer/src/main/java/com/hanmo/flowplan/task/application/validatpr/TaskValidator.java
+++ b/FlowPlanServer/src/main/java/com/hanmo/flowplan/task/application/validatpr/TaskValidator.java
@@ -1,0 +1,47 @@
+package com.hanmo.flowplan.task.application.validatpr;
+
+import com.hanmo.flowplan.project.domain.Project;
+import com.hanmo.flowplan.projectMember.application.validator.ProjectMemberValidator;
+import com.hanmo.flowplan.task.domain.Task;
+import com.hanmo.flowplan.task.domain.TaskRepository;
+import com.hanmo.flowplan.user.domain.User;
+import com.hanmo.flowplan.user.domain.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component // ⭐️ Spring Bean으로 등록
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TaskValidator {
+
+  private final TaskRepository taskRepository;
+  private final UserRepository userRepository;
+  private final ProjectMemberValidator projectMemberValidator; // ⭐️ 기존 검증기 재사용
+
+  public Task validateAndGetParentTask(Long parentId) {
+    if (parentId == null) {
+      return null; // 부모가 없는 최상위 작업 (정상)
+    }
+
+    // 부모 ID가 있는데 DB에 존재하지 않으면 예외 발생
+    return taskRepository.findById(parentId)
+        .orElseThrow(() -> new IllegalArgumentException("Parent task not found with id: " + parentId));
+  }
+
+  public User validateAndGetAssignee(Project project, Long assigneeId) {
+    if (assigneeId == null) {
+      return null; // 담당자가 없음 (정상)
+    }
+
+    // 1. User 존재 확인
+    User assignee = userRepository.findById(assigneeId)
+        .orElseThrow(() -> new IllegalArgumentException("Assignee user not found with id: " + assigneeId));
+
+    // 2. ⭐️ Project 멤버 검증 로직 위임
+    projectMemberValidator.validateMembership(assignee.getGoogleId(), project.getId());
+
+    return assignee; // 모든 검증 통과
+  }
+
+}

--- a/FlowPlanServer/src/main/java/com/hanmo/flowplan/task/domain/Task.java
+++ b/FlowPlanServer/src/main/java/com/hanmo/flowplan/task/domain/Task.java
@@ -3,11 +3,13 @@ package com.hanmo.flowplan.task.domain;
 import com.hanmo.flowplan.global.common.BaseTimeEntity;
 import com.hanmo.flowplan.project.domain.Project; // Project 엔티티 import (경로 확인 필요)
 import com.hanmo.flowplan.projectMember.domain.ProjectMember;
+import com.hanmo.flowplan.task.presentation.dto.UpdateTaskRequestDto;
 import com.hanmo.flowplan.user.domain.User;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime; // ERD의 DATETIME 타입에 매핑
@@ -15,6 +17,7 @@ import java.time.format.DateTimeFormatter;
 
 @Entity
 @Getter
+@Setter
 @Table(name = "tasks") // ERD의 테이블 이름과 일치
 @NoArgsConstructor
 public class Task extends BaseTimeEntity {
@@ -73,6 +76,36 @@ public class Task extends BaseTimeEntity {
 
   public void setParent(Task parent) {
     this.parent = parent;
+  }
+
+  public void update(UpdateTaskRequestDto dto, User newAssignee, TaskStatus newStatus) {
+
+    // 1. 이름 수정
+    if (dto.name() != null && !dto.name().isBlank()) {
+      this.name = dto.name();
+    }
+
+    // 2. 날짜 수정 (간트차트)
+    if (dto.startDate() != null) {
+      this.startDate = dto.startDate();
+    }
+    if (dto.endDate() != null) {
+      this.endDate = dto.endDate();
+    }
+
+    // 3. 상태 수정 (칸반보드)
+    if (newStatus != null) {
+      this.status = newStatus;
+    }
+
+    if (dto.progress() != null) {
+      this.progress = dto.progress();
+    }
+
+    // 4. 담당자 수정
+    if (newAssignee != null) {
+      this.assignee = newAssignee;
+    }
   }
 
   private LocalDateTime parseDate(String dateString) {

--- a/FlowPlanServer/src/main/java/com/hanmo/flowplan/task/domain/TaskRepository.java
+++ b/FlowPlanServer/src/main/java/com/hanmo/flowplan/task/domain/TaskRepository.java
@@ -2,5 +2,8 @@ package com.hanmo.flowplan.task.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TaskRepository extends JpaRepository<Task, Long> {
+  List<Task> findAllByProjectId(Long projectId);
 }

--- a/FlowPlanServer/src/main/java/com/hanmo/flowplan/task/presentation/TaskController.java
+++ b/FlowPlanServer/src/main/java/com/hanmo/flowplan/task/presentation/TaskController.java
@@ -1,30 +1,60 @@
-//package com.hanmo.flowplan.task.presentation;
-//
-//import com.hanmo.flowplan.global.jwt.CustomUserDetails;
-//import com.hanmo.flowplan.task.application.TaskService;
-//import io.swagger.v3.oas.annotations.tags.Tag;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.http.ResponseEntity;
-//import org.springframework.security.core.annotation.AuthenticationPrincipal;
-//import org.springframework.web.bind.annotation.GetMapping;
-//import org.springframework.web.bind.annotation.PathVariable;
-//import org.springframework.web.bind.annotation.RequestMapping;
-//import org.springframework.web.bind.annotation.RestController;
-//
-//@Tag(name = "Task API", description = "Task 관련 API")
-//@RestController
-//@RequestMapping("/api/tasks")
-//@RequiredArgsConstructor
-//public class TaskController {
-//  private final TaskService taskService;
-//
-//  // ⭐️ WBS 조회 API ⭐️
-//  @GetMapping
-//  public ResponseEntity<List<TaskResponseDto>> getTasksForProject(@PathVariable Long projectId,
-//                                                                  @AuthenticationPrincipal CustomUserDetails userDetails) {
-//    // (필요하다면) userDetails.getGoogleId()로 이 프로젝트 멤버가 맞는지
-//    // ProjectService나 ProjectMemberService를 통해 검증하는 로직 추가
-//    List<TaskResponseDto> tasks = taskService.getTasksByProjectId(projectId);
-//    return ResponseEntity.ok(tasks);
-//  }
-//}
+package com.hanmo.flowplan.task.presentation;
+
+import com.hanmo.flowplan.task.application.TaskService;
+// ⭐️ 1. DTO 클래스들을 import 합니다.
+import com.hanmo.flowplan.task.presentation.dto.CreateTaskRequestDto;
+import com.hanmo.flowplan.task.presentation.dto.TaskFlatResponseDto;
+import com.hanmo.flowplan.task.presentation.dto.UpdateTaskRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/tasks")
+public class TaskController {
+
+  private final TaskService taskService;
+
+  @GetMapping("/projects/{projectId}/tasks")
+  public ResponseEntity<List<TaskFlatResponseDto>> getTasks(@PathVariable Long projectId,
+                                                            @AuthenticationPrincipal String googleId) {
+    // TaskService에 권한 검증 및 조회를 위임
+    List<TaskFlatResponseDto> tasks = taskService.getTasks(projectId, googleId);
+    return ResponseEntity.ok(tasks);
+  }
+
+  @PostMapping("/projects/{projectId}/tasks")
+  public ResponseEntity<TaskFlatResponseDto> createTask(@PathVariable Long projectId,
+                                                        @RequestBody CreateTaskRequestDto requestDto,
+                                                        @AuthenticationPrincipal String googleId) {
+    // TaskService에 권한 검증, 생성, 저장을 위임
+    TaskFlatResponseDto createdTask = taskService.createTask(projectId, requestDto, googleId);
+
+    // ⭐️ HTTP 201 Created 응답 반환
+    return ResponseEntity.status(HttpStatus.CREATED).body(createdTask);
+  }
+
+  @PatchMapping("/tasks/{taskId}")
+  public ResponseEntity<TaskFlatResponseDto> updateTask(@PathVariable Long taskId,
+                                                        @RequestBody UpdateTaskRequestDto requestDto,
+                                                        @AuthenticationPrincipal String googleId) {
+    // TaskService에 권한 검증 및 수정을 위임
+    TaskFlatResponseDto updatedTask = taskService.updateTask(taskId, requestDto, googleId);
+    return ResponseEntity.ok(updatedTask);
+  }
+
+  @DeleteMapping("/tasks/{taskId}")
+  public ResponseEntity<Void> deleteTask(@PathVariable Long taskId,
+                                         @AuthenticationPrincipal String googleId  ) {
+    // TaskService에 권한 검증 및 삭제를 위임
+    taskService.deleteTask(taskId, googleId);
+
+    // ⭐️ HTTP 204 No Content 응답 반환
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/FlowPlanServer/src/main/java/com/hanmo/flowplan/task/presentation/dto/CreateTaskRequestDto.java
+++ b/FlowPlanServer/src/main/java/com/hanmo/flowplan/task/presentation/dto/CreateTaskRequestDto.java
@@ -1,0 +1,22 @@
+package com.hanmo.flowplan.task.presentation.dto;
+
+import java.time.LocalDateTime;
+
+/**
+ * API 2: 신규 작업 생성을 위한 Request Body DTO
+ * (TaskController에서 @RequestBody로 받습니다)
+ */
+public record CreateTaskRequestDto(
+    String name,
+
+    // ⭐️ 부모 Task ID (Task 엔티티의 PK, 최상위 작업이면 null)
+    Long parentId,
+    // ⭐️ 담당자 ID (User 엔티티의 PK, 할당 안 하면 null)
+    Long assigneeId,
+
+    String startDate,
+    String endDate,
+
+    String status,   // (예: "TODO", "IN_PROGRESS", "DONE")
+    Integer progress // (기본값 0)
+) {}

--- a/FlowPlanServer/src/main/java/com/hanmo/flowplan/task/presentation/dto/TaskFlatResponseDto.java
+++ b/FlowPlanServer/src/main/java/com/hanmo/flowplan/task/presentation/dto/TaskFlatResponseDto.java
@@ -1,0 +1,48 @@
+package com.hanmo.flowplan.task.presentation.dto;
+
+import com.hanmo.flowplan.task.domain.Task;
+import com.hanmo.flowplan.task.domain.TaskStatus;
+import java.time.LocalDateTime;
+
+/**
+ * ⭐️ 작업 조회 응답용 DTO (Flat 구조, Record 형식)
+ * 프론트엔드 간트차트/칸반 라이브러리에 최적화되었습니다.
+ */
+public record TaskFlatResponseDto(
+    Long id, // ⭐️ 라이브러리가 사용할 "id"
+    Long parentId, // ⭐️ 라이브러리가 사용할 "parent_id"
+    String name,
+    LocalDateTime startDate,
+    LocalDateTime endDate,
+    int progress,
+    TaskStatus status,
+    String recommendedRole, // AI 추천 역할
+    String assigneeName    // 실제 담당자 이름
+) {
+
+  /**
+   * ⭐️ 엔티티 -> DTO 변환 (재귀 없음)
+   * Task 엔티티를 받아서 TaskFlatResponseDto 레코드를 생성하는 정적 팩토리 메서드
+   */
+  public static TaskFlatResponseDto from(Task task) {
+
+    // ⭐️ 부모 Task가 있으면 부모의 ID를, 없으면 null
+    Long parentId = (task.getParent() != null) ? task.getParent().getId() : null;
+
+    // ⭐️ 담당자(User)가 할당되었으면 이름을, 없으면 null
+    String assigneeName = (task.getAssignee() != null) ? task.getAssignee().getName() : null;
+
+    // ⭐️ 레코드의 생성자(Canonical Constructor) 호출
+    return new TaskFlatResponseDto(
+        task.getId(),
+        parentId,
+        task.getName(),
+        task.getStartDate(),
+        task.getEndDate(),
+        task.getProgress(),
+        task.getStatus(),
+        task.getRecommendedRole(),
+        assigneeName
+    );
+  }
+}

--- a/FlowPlanServer/src/main/java/com/hanmo/flowplan/task/presentation/dto/UpdateTaskRequestDto.java
+++ b/FlowPlanServer/src/main/java/com/hanmo/flowplan/task/presentation/dto/UpdateTaskRequestDto.java
@@ -1,0 +1,14 @@
+package com.hanmo.flowplan.task.presentation.dto;
+
+import java.time.LocalDateTime;
+
+// ⭐️ 모든 필드가 null일 수 있습니다.
+// (Gantt는 startDate/endDate만, Kanban은 status만 보냄)
+public record UpdateTaskRequestDto(
+    String name,
+    Long assigneeId, // User ID 또는 ProjectMember ID
+    LocalDateTime startDate,
+    LocalDateTime endDate,
+    String status,
+    Integer progress
+) {}

--- a/FlowPlanServer/src/test/java/com/hanmo/flowplan/AuthServiceTest.java
+++ b/FlowPlanServer/src/test/java/com/hanmo/flowplan/AuthServiceTest.java
@@ -43,7 +43,7 @@ class AuthServiceTest {
     void loginWithGoogle_신규사용자면_저장하고_RT저장_토큰반환() {
         // given
         given(googleIdTokenVerifierService.verify(ID_TOKEN))
-                .willReturn(new GoogleUserInfo(GOOGLE_USER_ID, EMAIL));
+                .willReturn(new GoogleUserInfo(GOOGLE_USER_ID, EMAIL, NAME));
 
         User savedUser = User.builder()
                 .googleId(GOOGLE_USER_ID)
@@ -82,7 +82,7 @@ class AuthServiceTest {
     void loginWithGoogle_기존사용자면_save_없이_RT저장_토큰반환() {
         // given
         given(googleIdTokenVerifierService.verify(ID_TOKEN))
-                .willReturn(new GoogleUserInfo(GOOGLE_USER_ID, EMAIL));
+                .willReturn(new GoogleUserInfo(GOOGLE_USER_ID, EMAIL, NAME));
 
         User existing = User.builder()
                 .googleId(GOOGLE_USER_ID)
@@ -113,8 +113,8 @@ class AuthServiceTest {
         JwtToken newTokens = new JwtToken("Bearer", newAT, newRT);
 
         willDoNothing().given(jwtProvider).assertRefreshToken(oldRT);
-        given(jwtProvider.getUsernameFromToken(oldRT)).willReturn(EMAIL);
-        given(refreshTokenStore.get(EMAIL)).willReturn(oldRT);
+        given(jwtProvider.getGoogleIdFromToken(oldRT)).willReturn(GOOGLE_USER_ID);
+        given(refreshTokenStore.get(GOOGLE_USER_ID)).willReturn(oldRT);
         given(jwtProvider.reissue(oldRT)).willReturn(newTokens);
 
         // when
@@ -132,7 +132,7 @@ class AuthServiceTest {
         // given
         String oldRT = "RT-old";
         willDoNothing().given(jwtProvider).assertRefreshToken(oldRT);
-        given(jwtProvider.getUsernameFromToken(oldRT)).willReturn(EMAIL);
+        given(jwtProvider.getGoogleIdFromToken(oldRT)).willReturn(GOOGLE_USER_ID);
         given(refreshTokenStore.get(EMAIL)).willReturn("DIFFERENT-RT");
 
         // when / then
@@ -149,7 +149,7 @@ class AuthServiceTest {
     void logout_AT있으면_RT삭제() {
         // given
         String accessToken = "AT-xxx";
-        given(jwtProvider.getUsernameFromToken(accessToken)).willReturn(EMAIL);
+        given(jwtProvider.getGoogleIdFromToken(accessToken)).willReturn(GOOGLE_USER_ID);
 
         // when
         service.logout(accessToken);


### PR DESCRIPTION
WBS 작업을 관리하기 위한 전체 CRUD API를 구현하고,
유지보수성을 위해 검증 로직을 별도 Validator로 분리했습니다.
또한, 403 Forbidden 오류 해결을 위해 인증 객체 생성 로직을 수정했습니다.

[Task 도메인]
- 작업 조회(Flat 구조), 생성, 수정(PATCH), 삭제 API 구현 (TaskController)
- TaskService에 비즈니스 로직 구현 및 Task 엔티티에 수정 로직(update) 캡슐화
- 프론트엔드 라이브러리 지원을 위한 Flat 구조 DTO (TaskFlatResponseDto) 적용

[리팩토링 & 검증]
- 서비스 비대화를 막기 위해 검증 로직 분리
  - TaskValidator: 작업 존재 여부 및 담당자 유효성 검증
  - ProjectMemberValidator: 프로젝트 멤버십 권한 검증
- ProjectService 등 기존 서비스에서 Validator를 사용하도록 리팩토링

[인증(Auth) 수정]
- CustomUserDetails: 권한 목록(getAuthorities) 반환 로직 수정 (403 해결)
- SecurityConfig: 필터 설정 및 경로 권한 점검